### PR TITLE
Update current lib css with overlay fix

### DIFF
--- a/source/css/lib/govlab-styleguide.css
+++ b/source/css/lib/govlab-styleguide.css
@@ -4578,7 +4578,6 @@ Styleguide 1.2
   right: 0;
   z-index: 10;
   display: none;
-  background-color: red;
   opacity: .1; }
   #overlay.m-active {
     display: block; }


### PR DESCRIPTION
Updating the current libCss to incorporate overlay color fix. 

@mocxd, when you do npm update, I think you have to manually do `gulp libCss` to pull in the most recent styleguide, and probably the same for libJs. Is this okay or do you want to gulp.watch these even though theoretically they shouldn't be changed?
